### PR TITLE
Add GitHub action to automatically publish extension

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,19 @@
+name: Deploy Extension
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm install
+      - uses: lannonbr/vsce-action@3.0.0
+        with:
+          args: "publish -p $VSCE_TOKEN"
+        env:
+          VSCE_TOKEN: ${{ secrets.VSCE_TOKEN }}


### PR DESCRIPTION
GitHub Actions script to publish to the Visual Studio Marketplace automatically on merge to master. Two points to consider:

* ⚠️ Access token needs to be added to the repo as a secret `VSCE_TOKEN` to work
* The `version` needs to be update in `package.json` before merge to master for this to work
    * If not, the publishing will fail. Can just update and push to master again and it's fine.

This action is copied from the [nf-core extension pack](https://github.com/nf-core/vscode-extensionpack) where we have been using it successfully for several years.