### PR TITLE
Update publishing workflow to also publish to Open VSX Registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,9 +11,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: npm install
-      - uses: lannonbr/vsce-action@3.0.0
+
+      - uses: actions/setup-node@v4
         with:
-          args: "publish -p $VSCE_TOKEN"
-        env:
-          VSCE_TOKEN: ${{ secrets.VSCE_TOKEN }}
+          node-version: 20
+          cache: "npm"
+
+      - name: npm clean install
+        run: npm ci
+
+      - name: Publish to Open VSX Registry
+        uses: HaaLeo/publish-vscode-extension@v1
+        with:
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
+
+      - name: Publish to Visual Studio Marketplace
+        uses: HaaLeo/publish-vscode-extension@v1
+        with:
+          pat: ${{ secrets.VSCE_TOKEN }}
+          registryUrl: https://marketplace.visualstudio.com

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to the "nextflow" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [0.3.3] - 2024-03-29
+
+- Update publishing automation to also push to the Open VSX Registry.
+
 ## [0.3.2] - 2024-03-25
 - Updated Nextflow logo
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,15 @@
+{
+    "name": "nextflow",
+    "version": "0.3.2",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "nextflow",
+            "version": "0.3.2",
+            "engines": {
+                "vscode": "^1.19.0"
+            }
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "nextflow",
     "displayName": "Nextflow",
     "description": "Nextflow language support",
-    "version": "0.3.2",
+    "version": "0.3.3",
     "publisher": "nextflow",
     "repository": {
         "type": "git",


### PR DESCRIPTION
> [!WARNING]
> Do not merge until we have claimed ownership of the Nextflow plugin at the Open VSX Registry: https://open-vsx.org/extension/nextflow/nextflow

Once claimed, need to generate a PAT and add to this repo. Then we can merge and it should deploy.