### PR TITLE
Use Nextflow theme for Mermaid diagrams

### DIFF
--- a/src/main/ts/extension.ts
+++ b/src/main/ts/extension.ts
@@ -114,8 +114,21 @@ async function previewDag(uri: string, name?: string) {
     </pre>
     <script type="module">
       import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
-      mermaid.initialize({ startOnLoad: true });
-    </script>
+      mermaid.initialize({
+        startOnLoad: true,
+        theme: 'base',
+        themeVariables: {
+          fontFamily: 'Inter',
+          primaryColor: '#0DC09D',
+          primaryTextColor: '#fff',
+          secondaryColor: '#3D95FD',
+          secondaryTextColor: '#000000',
+          tertiaryColor: '#fff',
+          noteTextColor: '#050505',
+          edgeLabelBackground: '#7B7B7B',
+        }
+      });
+      </script>
     </body>
     </html>
   `;


### PR DESCRIPTION
Trying to add a Nextflow theme to the Mermaid diagrams

Here's what it looks like right now: 

![image](https://github.com/user-attachments/assets/47aec02b-146d-4570-874d-a7206b328529)

So need to load the Inter font or find an alternative, and need to either flesh out the base theme or build off a different theme.