### PR TITLE
Add device flow authentication POC

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,6 +124,11 @@
         "command": "nextflow.writeTest",
         "title": "Write nf-test with Seqera",
         "category": "Nextflow"
+      },
+      {
+        "command": "nextflow.login",
+        "title": "Login to Seqera",
+        "category": "Nextflow"
       }
     ],
     "configuration": {

--- a/src/activateAuth.ts
+++ b/src/activateAuth.ts
@@ -1,0 +1,22 @@
+import * as vscode from "vscode";
+import startDeviceFlow from "./auth/startDeviceFlow";
+import fetchUserInfo from "./tower/fetchUserInfo";
+import { varNames } from "./auth/constants";
+
+export async function activateAuth(context: vscode.ExtensionContext) {
+  console.log("🟢 Seqera: Activating Auth");
+
+  context.secrets.onDidChange(async (e) => {
+    if (e.key === varNames.accessToken) {
+      const token = await context.secrets.get(varNames.accessToken);
+      if (!token) return;
+      const userInfo = await fetchUserInfo(context, token);
+    }
+  });
+
+  const loginCmd = vscode.commands.registerCommand("nextflow.login", () => {
+    startDeviceFlow(context);
+  });
+
+  context.subscriptions.push(loginCmd);
+}

--- a/src/activateChatbot.ts
+++ b/src/activateChatbot.ts
@@ -7,6 +7,8 @@ export function activateChatbot(context: vscode.ExtensionContext) {
     return;
   }
 
+  console.log("🟢 Seqera: Activating Chatbot");
+
   // Create the chat participant
   const chatHandler = createHandler();
   const chatParticipant = vscode.chat.createChatParticipant(

--- a/src/activateLanguageServer.ts
+++ b/src/activateLanguageServer.ts
@@ -274,6 +274,7 @@ function onDidChangeConfiguration(event: vscode.ConfigurationChangeEvent) {
 }
 
 function activateLanguageServer(context: vscode.ExtensionContext) {
+  console.log("🟢 Seqera: Activating Nextflow server");
   javaPath = findJava();
   extensionContext = context;
   vscode.workspace.onDidChangeConfiguration(onDidChangeConfiguration);

--- a/src/auth/constants.ts
+++ b/src/auth/constants.ts
@@ -1,0 +1,6 @@
+export const client_id = "p3sXf6GJaOWmmQKONQHsjxg15VHgDwoK";
+export const auth0Domain = "seqera-development.eu.auth0.com";
+
+export const varNames = {
+  accessToken: "nextflow.accessToken",
+};

--- a/src/auth/getConfig.ts
+++ b/src/auth/getConfig.ts
@@ -1,0 +1,33 @@
+import { client_id, auth0Domain } from "./constants";
+
+export type Auth0Config = {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  verification_uri_complete?: string;
+  expires_in: number;
+  interval: number;
+};
+
+async function getConfig(): Promise<Auth0Config> {
+  const configEndpoint = `https://${auth0Domain}/oauth/device/code`;
+
+  const response = await fetch(configEndpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id,
+      scope: "openid email profile",
+      audience: "https://seqera-development.eu.auth0.com/api/v2/",
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to get auth0 config: ${response.statusText}`);
+  }
+
+  const responseBody = await response.json();
+  return responseBody as Auth0Config;
+}
+
+export default getConfig;

--- a/src/auth/pollForToken.ts
+++ b/src/auth/pollForToken.ts
@@ -1,0 +1,78 @@
+import type { Auth0Config } from "./getConfig";
+import { client_id, auth0Domain } from "./constants";
+
+type TokenResponse = {
+  access_token: string;
+  refresh_token?: string;
+  id_token: string;
+  token_type: string;
+  expires_in: number;
+  scope?: string;
+  error?: string;
+};
+
+async function fetchToken(config: Auth0Config): Promise<Response> {
+  const tokenEndpoint = `https://${auth0Domain}/oauth/token`;
+  return await fetch(tokenEndpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+      device_code: config.device_code,
+      client_id,
+    }),
+  });
+}
+
+async function pollForToken(
+  config: Auth0Config
+): Promise<TokenResponse | null> {
+  const startTime = Date.now();
+  const interval = config.interval * 1000;
+  const expiresIn = config.expires_in * 1000;
+
+  console.log("🟢 Seqera: Polling for token");
+
+  while (true) {
+    // Sleep a moment
+    await new Promise((resolve) => setTimeout(resolve, interval));
+
+    // Attempt to fetch the token
+    const response = await fetchToken(config);
+    if (!response) continue;
+
+    const responseBody = (await response.json()) as TokenResponse;
+    const errorCode = responseBody.error;
+
+    // Return token on success
+    if (!errorCode) {
+      console.log("🟠 auth0", responseBody);
+      return responseBody;
+    }
+
+    const isPending = errorCode === "authorization_pending";
+    const timeElapsed = Date.now() - startTime;
+
+    // Repeat if pending
+    if (isPending) continue;
+
+    // Exit if time exceeded
+    if (timeElapsed > expiresIn) {
+      throw new Error("Device flow timeout expired.");
+    }
+
+    // Otherwise exit
+    throw new Error(`Device flow error: ${errorCode}`);
+  }
+}
+
+export default async (config: Auth0Config): Promise<TokenResponse | null> => {
+  try {
+    const token = await pollForToken(config);
+    return token;
+  } catch (error: any) {
+    console.log("🔴 Seqera:", error.message);
+    console.error(error);
+    return null;
+  }
+};

--- a/src/auth/startDeviceFlow.ts
+++ b/src/auth/startDeviceFlow.ts
@@ -1,0 +1,36 @@
+import * as vscode from "vscode";
+import pollForToken from "./pollForToken";
+import getConfig from "./getConfig";
+import { varNames } from "./constants";
+
+async function startDeviceFlow(context: vscode.ExtensionContext) {
+  // Get our tenant config
+  const config = await getConfig();
+
+  // Open our auth page
+  let destinationURL: string | vscode.Uri =
+    config.verification_uri_complete || config.verification_uri;
+  destinationURL = vscode.Uri.parse(destinationURL);
+  vscode.env.openExternal(destinationURL);
+
+  // Wait for user, get token
+  const user = await pollForToken(config);
+
+  // Exit if failed
+  if (!user) return;
+
+  // Store token in SecretStorage
+  console.log("🟢 Seqera: Storing access token");
+  await context.secrets.store(varNames.accessToken, user.access_token);
+
+  // Inform on success
+  vscode.window.showInformationMessage("Signed in to Seqera");
+}
+
+export default async (context: vscode.ExtensionContext) => {
+  try {
+    await startDeviceFlow(context);
+  } catch (err: any) {
+    vscode.window.showErrorMessage(err.message);
+  }
+};

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,11 +5,13 @@ import {
   stopLanguageServer
 } from "./activateLanguageServer";
 import { activateReadme } from "./activateReadme";
+import { activateAuth } from "./activateAuth";
 
 export function activate(context: vscode.ExtensionContext) {
   activateReadme(context);
   activateChatbot(context);
   activateLanguageServer(context);
+  activateAuth(context);
 }
 
 export function deactivate(): Thenable<void> | undefined {

--- a/src/tower/constants.ts
+++ b/src/tower/constants.ts
@@ -1,0 +1,4 @@
+let platformApiUrl = process.env.PUBLIC_PLATFORM_API_BASE_URL;
+if (!platformApiUrl) platformApiUrl = "https://dev-tower.net";
+
+export { platformApiUrl };

--- a/src/tower/fetchUserInfo.ts
+++ b/src/tower/fetchUserInfo.ts
@@ -1,0 +1,83 @@
+import * as vscode from "vscode";
+import { platformApiUrl } from "./constants";
+import { varNames } from "../auth/constants";
+
+export type User = {
+  id: number;
+  userName: string;
+  email: string;
+  firstName?: string;
+  lastName?: string;
+  organization?: string;
+  description?: string;
+  avatar?: string;
+  avatarId?: string;
+  notification?: string;
+  termsOfUseConsent: boolean;
+  marketingConsent: boolean;
+  lastAccess: string;
+  dateCreated: string;
+  lastUpdated: string;
+  deleted: boolean;
+  trusted: boolean;
+  options: {
+    githubToken?: string;
+    maxRuns?: number;
+    hubspotId?: number;
+  };
+};
+
+export type UserInfo = {
+  user: User;
+  needConsent: boolean;
+  defaultWorkspaceId: number;
+};
+
+const fetchUserInfo = async (
+  context: vscode.ExtensionContext,
+  token: string
+): Promise<UserInfo | null> => {
+  const accessToken = await context.secrets.get(varNames.accessToken);
+  const endpointURL = `${platformApiUrl}/api/user-info`;
+
+  if (!accessToken) {
+    console.log("🔴 Seqera: No access token stored");
+    return null;
+  } else {
+    console.log("🟢 Seqera: Access token found, attempting to fetch user info");
+  }
+
+  const response = await fetch(endpointURL, {
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (response.status === 401) {
+    const json = await response.text();
+    console.log("🟣 401", response);
+    console.log("🟣 401", json);
+    await context.secrets.delete(varNames.accessToken);
+    throw new Error("Failed to fetch user info, deleted access token");
+  }
+
+  const data = await response.json();
+  console.log("🟣", response);
+  console.log("🟣", data);
+  return data as UserInfo;
+};
+
+export default async (
+  context: vscode.ExtensionContext,
+  token: string
+): Promise<UserInfo | null> => {
+  try {
+    return await fetchUserInfo(context, token);
+  } catch (error: any) {
+    console.log("🔴 Seqera:", error.message);
+    console.error(error);
+    return null;
+  }
+};


### PR DESCRIPTION
[seqera.atlassian.net/browse/SH-488](https://seqera.atlassian.net/browse/SH-488)

Based on [Device Authorization Flow](https://auth0.com/docs/get-started/authentication-and-authorization-flow/device-authorization-flow) as per Auth0 docs

First steps for authentication: adds a command Login to Seqera, which takes the user to our Auth0 page. Once authenticated, the token is stored as a secret, and can then be used in subsequent requests to our API. I've started with a request to user-info, which is returning 401. I'm not entirely sure what the next step is - but I suppose the dev deployment needs to be updated to accept the newly added Auth0 [application](https://manage.auth0.com/dashboard/eu/seqera-development/applications/p3sXf6GJaOWmmQKONQHsjxg15VHgDwoK/settings)? @swampie mentioned that we should be able to use the token as our PAT

Note that this PR is on our fork of the nextflow extension repo, but could be rebased as needed