### PR TITLE
Tweak popup message

### DIFF
--- a/src/languageServer/index.ts
+++ b/src/languageServer/index.ts
@@ -103,7 +103,7 @@ async function getLanguageServerPath(context: vscode.ExtensionContext) {
   const fileUri = vscode.Uri.file(cachePath);
   await vscode.workspace.fs.writeFile(fileUri, new Uint8Array(arrayBuffer));
   vscode.window.showInformationMessage(
-    `Downloaded language server ${resolvedVersion}.`
+    `Downloaded Nextflow language server ${resolvedVersion}.`
   );
   return fileUri.fsPath;
 }


### PR DESCRIPTION
Specify "Nextflow" in popup message about downloading language server.

This just came up when I was using VSCode for a totally different project, so wasn't at all clear that it was anything to do with Nextflow. Adding this word is a minor tweak that may help slightly.