### PR TITLE
Fix: Prevent 'postMessage' error during command palette login

### DIFF
--- a/src/webview/WebviewProvider/lib/platform/fetchPlatformData.ts
+++ b/src/webview/WebviewProvider/lib/platform/fetchPlatformData.ts
@@ -15,16 +15,16 @@ type PlatformData = {
 function handleUpdate(
   data: PlatformData,
   context: ExtensionContext,
-  view: WebviewView["webview"]
+  view?: WebviewView["webview"]
 ) {
   const vsCodeState = context.workspaceState;
   vsCodeState.update("platformData", data);
-  view.postMessage(data);
+  view?.postMessage(data);
 }
 
 const fetchPlatformData = async (
   accessToken: string,
-  view: WebviewView["webview"],
+  view: WebviewView["webview"] | undefined,
   context: ExtensionContext,
   refresh?: boolean
 ): Promise<PlatformData> => {
@@ -34,7 +34,7 @@ const fetchPlatformData = async (
   let hasExpired = expired(savedAuth?.tokenExpiry);
 
   if (!hasExpired && !refresh) {
-    view.postMessage(savedState);
+    view?.postMessage(savedState);
     return savedState as PlatformData;
   }
 


### PR DESCRIPTION
The fetchPlatformData and handleUpdate functions were modified to gracefully handle cases where the webview is not available, by making the webview parameter optional and using optional chaining for postMessage calls. This ensures the login process completes successfully even if the webview isn't open, and the session is correctly established.

Adam found this by trying to log in with Cmd+Shift+P but not having a webview open.