### PR TITLE
Add configuration option `nextflow.dag.showVariables` to toggle rendering of variable nodes in DAG preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ The following settings are available:
 
 - `nextflow.telemetry.enabled`: Enable usage data to be sent to Seqera. See the [welcome page](./src/welcomePage/welcome-vscode.md) for more information about what we do and do not collect.
 
+- `nextflow.dag.showVariables`: Specify if script variables should be shown in DAG preview
+
 ## Telemetry notice
 
 We (Seqera) collect limited usage data through this extension to help us understand which features are most valuable and improve your overall experience.

--- a/package.json
+++ b/package.json
@@ -253,6 +253,11 @@
           "type": "boolean",
           "default": false,
           "markdownDescription": "Enable usage data to be sent to Seqera. See the welcome page for more information about what we do and do not collect."
+        },
+        "nextflow.dag.showVariables": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Show variables along with processes in DAG preview"
         }
       }
     },


### PR DESCRIPTION
For details see the [`language-server PR`](https://github.com/nextflow-io/language-server/pull/131).