### PR TITLE
Fix the font color for Project view

### DIFF
--- a/webview-ui/src/components/FileList/styles.module.css
+++ b/webview-ui/src/components/FileList/styles.module.css
@@ -13,7 +13,7 @@
   line-height: 1;
   display: flex;
   align-items: center;
-  color: var(--vscode-list-activeSelectionForeground);
+  color: var(--vscode-foreground);
   overflow: hidden;
   flex: 1 1 auto;
   cursor: pointer;

--- a/webview-ui/src/components/FileNode/styles.module.css
+++ b/webview-ui/src/components/FileNode/styles.module.css
@@ -8,7 +8,7 @@
     justify-content: space-between;
     width: 100%;
     cursor: pointer;
-    color: var(--vscode-list-activeSelectionForeground);
+    color: var(--vscode-foreground);
     &:hover {
       background-color: var(--vscode-list-hoverBackground);
     }

--- a/webview-ui/src/components/Select/styles.module.css
+++ b/webview-ui/src/components/Select/styles.module.css
@@ -106,7 +106,7 @@
 
 .selected {
   background-color: var(--vscode-list-activeSelectionBackground);
-  color: var(--vscode-list-activeSelectionForeground);
+  color: var(--vscode-foreground);
 }
 
 .outerLabel {


### PR DESCRIPTION
Fixes the font color for Project view when using the Default Light theme:

<img width="475" height="864" alt="image" src="https://github.com/user-attachments/assets/d7b306f7-ad25-4ccf-8b8a-407eca4a085b" />

<img width="453" height="917" alt="image" src="https://github.com/user-attachments/assets/63375ed8-4987-467c-b565-a11fffe43dfb" />
