### PR TITLE
Fix error in checkJavaVersion when java path has spaces

### DIFF
--- a/src/languageServer/utils/findJava.ts
+++ b/src/languageServer/utils/findJava.ts
@@ -48,7 +48,7 @@ export function findJava(): string | null {
 }
 
 export function checkJavaVersion(javaPath: string): boolean {
-  const output = cp.execSync(`${javaPath} -version 2>&1`, { encoding: 'utf8' });
+  const output = cp.execSync(`"${javaPath}" -version 2>&1`, { encoding: 'utf8' });
   const match = output.match(/version "(.*?)"/);
   if (!match || match.length < 2) {
     throw new Error('Could not parse Java version');


### PR DESCRIPTION
For Windows Users, the problem can be reproduced by setting the following in your settings.json. This is where I have my jdk installed, but this will reproduce for any jdk installed in a path containing whitespace:

```json
{
  "nextflow.java.home": "C:\\Program Files\\Microsoft\\jdk-17.0.16.8-hotspot"
}
```

The resulting error would be that the command "C:\\Program Files\\Microsoft\\jdk-17.0.16.8-hotspot -version 2>&1" failed.

As a temporary workaround, one could set instead:

```json
{
  "nextflow.java.home": "C:\\Progra~1\\Microsoft\\jdk-17.0.16.8-hotspot"
}
```