### PR TITLE
Update default exclusion list in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -211,10 +211,11 @@
           },
           "default": [
             ".git",
+            ".lineage",
             ".nf-test",
-            "work",
+            ".pixi",
             ".venv",
-            ".pixi"
+            "work"
           ],
           "description": "Folders that should be excluded when scanning the workspace for Nextflow files."
         },

--- a/package.json
+++ b/package.json
@@ -212,7 +212,9 @@
           "default": [
             ".git",
             ".nf-test",
-            "work"
+            "work",
+            ".venv",
+            ".pixi"
           ],
           "description": "Folders that should be excluded when scanning the workspace for Nextflow files."
         },


### PR DESCRIPTION
Added '.venv' and '.pixi' to the default exclusion list.

See https://community.seqera.io/t/issue-with-nextflows-vs-code-parser-reading-my-venv-file/2611