### PR TITLE
Add nf-metro support for workflow DAGs and pipeline outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Nextflow VS Code extension will be documented here.
 
 See [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [Unreleased]
+
+- Add nf-metro support: preview metro maps from workflow DAGs and open nf-metro artifacts from pipeline output directories
+
 ## [1.7.1] - 2026-06-08
 
 - Add syntax highlighting and filtering for Nextflow log files (#197)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ See [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to
 ## [Unreleased]
 
 - Add nf-metro support: preview metro maps from workflow DAGs and open nf-metro artifacts from pipeline output directories
+- Detect Nextflow `-with-dag` `.mmd` exports when opening or scanning pipeline outputs
+- Improve nf-metro CLI discovery for common pip and conda install locations
 
 ## [1.7.1] - 2026-06-08
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The Project view allows you to:
 The extension integrates with [nf-metro](https://github.com/pinin4fjords/nf-metro) to visualize pipelines as transit-style metro maps:
 
 - **Preview Metro Map** — render a metro map from the current workflow DAG (same source as Nextflow `-with-dag`)
-- **Open Metro Map Preview** — open pre-rendered `.html`, `.svg`, or `.mmd` nf-metro files
+- **Open Metro Map Preview** — open pre-rendered `.html`, `.svg`, `.mmd` nf-metro files, or Nextflow `-with-dag` `.mmd` exports
 - **Find Metro Map Outputs** — scan common pipeline output directories (`results/`, `output/`, and configured `outputDir`) for nf-metro artifacts
 
 ### Copilot for Nextflow

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The extension uses the [Nextflow language server](https://github.com/nextflow-io
 - Hover hints
 - Rename
 - DAG preview for workflows
+- Metro map preview for workflows and pipeline outputs ([nf-metro](https://github.com/pinin4fjords/nf-metro))
 
 Read the [Nextflow documentation](https://nextflow.io/docs/latest/vscode.html) for more information about the Nextflow language server.
 
@@ -46,6 +47,14 @@ The Project view allows you to:
 - Navigate to a process, workflow, or test by name
 - Monitor test coverage across your entire pipeline
 
+### Metro map preview
+
+The extension integrates with [nf-metro](https://github.com/pinin4fjords/nf-metro) to visualize pipelines as transit-style metro maps:
+
+- **Preview Metro Map** — render a metro map from the current workflow DAG (same source as Nextflow `-with-dag`)
+- **Open Metro Map Preview** — open pre-rendered `.html`, `.svg`, or `.mmd` nf-metro files
+- **Find Metro Map Outputs** — scan common pipeline output directories (`results/`, `output/`, and configured `outputDir`) for nf-metro artifacts
+
 ### Copilot for Nextflow
 
 The Copilot extension for Seqera AI has been removed. Use the [Seqera AI CLI](https://seqera.io/blog/seqera-ai-cli-announcement/) instead.
@@ -59,6 +68,8 @@ This extension is available in the [Visual Studio Marketplace](https://marketpla
 The language server requires Java 17 or later.
 
 *Note: for custom Java installations such as conda, you might need to set the `nextflow.java.home` extension setting for the extension to find your Java installation.*
+
+Metro map preview requires the optional [nf-metro](https://github.com/pinin4fjords/nf-metro) CLI (`pip install nf-metro` or `conda install bioconda::nf-metro`). Set `nextflow.metro.path` if `nf-metro` is not on your `PATH`.
 
 ### Offline usage
 
@@ -110,6 +121,12 @@ The following settings are available:
 - `nextflow.log.filter.hiddenLevels`: Log levels to hide in `.nextflow.log` files when filtering is enabled. The file on disk is unchanged. Can be toggled per-file in the editor title bar.
 
 - `nextflow.log.filter.stripAnsi`: Remove ANSI escape codes (e.g. `\u001b[0;32m`) from `.nextflow.log` files when filtering is enabled. The file on disk is unchanged. Can be toggled per-file in the editor title bar.
+
+- `nextflow.metro.path`: Path to the `nf-metro` executable. If empty, the extension looks for `nf-metro` on `PATH`.
+
+- `nextflow.metro.theme`: Visual theme passed to nf-metro when rendering metro maps (`nfcore`, `light`, or `seqera`; `seqera` requires nf-metro 0.8+).
+
+- `nextflow.metro.format`: Output format for rendered metro maps (`html` or `svg`).
 
 - `nextflow.telemetry.enabled`: Enable usage data to be sent to Seqera. See [below](#telemetry-notice) for more information about what we do and do not collect.
 

--- a/package.json
+++ b/package.json
@@ -429,6 +429,7 @@
   "scripts": {
     "check-types": "tsc --noEmit",
     "test": "npm run check-types && node --experimental-strip-types --test src/metro/metro.test.ts",
+    "test:metro-smoke": "node --experimental-strip-types src/metro/smoke.integration.ts",
     "compile": "npm run check-types && npm run ui-build && node esbuild.js",
     "package": "npm run check-types && npm run ui-build && node esbuild.js --production && (cd build ; vsce package -o nextflow.vsix)",
     "ui-dev": "cd webview-ui && npm run dev",

--- a/package.json
+++ b/package.json
@@ -428,6 +428,7 @@
   },
   "scripts": {
     "check-types": "tsc --noEmit",
+    "test": "npm run check-types && node --experimental-strip-types --test src/metro/metro.test.ts",
     "compile": "npm run check-types && npm run ui-build && node esbuild.js",
     "package": "npm run check-types && npm run ui-build && node esbuild.js --production && (cd build ; vsce package -o nextflow.vsix)",
     "ui-dev": "cd webview-ui && npm run dev",

--- a/package.json
+++ b/package.json
@@ -170,6 +170,21 @@
         "title": "Reload Seqera Webview",
         "category": "Nextflow",
         "icon": "$(refresh)"
+      },
+      {
+        "command": "nextflow.previewMetro",
+        "title": "Preview Metro Map",
+        "category": "Nextflow"
+      },
+      {
+        "command": "nextflow.openMetroFile",
+        "title": "Open Metro Map Preview",
+        "category": "Nextflow"
+      },
+      {
+        "command": "nextflow.findMetroOutputs",
+        "title": "Find Metro Map Outputs",
+        "category": "Nextflow"
       }
     ],
     "menus": {
@@ -185,6 +200,37 @@
         {
           "command": "nextflow.log.filter.toggle",
           "when": "resourceLangId == nextflow-log"
+        },
+        {
+          "command": "nextflow.previewMetro",
+          "when": "resourceExtname == '.nf'"
+        },
+        {
+          "command": "nextflow.openMetroFile",
+          "when": "resourceExtname =~ /\\.(mmd|html|svg)$/"
+        },
+        {
+          "command": "nextflow.findMetroOutputs",
+          "when": "workspaceFolderCount > 0"
+        }
+      ],
+      "editor/context": [
+        {
+          "command": "nextflow.previewMetro",
+          "when": "resourceExtname == '.nf'",
+          "group": "navigation@1"
+        },
+        {
+          "command": "nextflow.openMetroFile",
+          "when": "resourceExtname =~ /\\.(mmd|html|svg)$/",
+          "group": "navigation@1"
+        }
+      ],
+      "explorer/context": [
+        {
+          "command": "nextflow.openMetroFile",
+          "when": "resourceExtname =~ /\\.(mmd|html|svg)$/",
+          "group": "navigation@1"
         }
       ],
       "view/title": [
@@ -324,6 +370,30 @@
           "type": "boolean",
           "default": true,
           "markdownDescription": "Remove ANSI escape codes (e.g. `\\u001b[0;32m`) from `.nextflow.log` files when filtering is enabled. The file on disk is unchanged. Can be toggled per-file in the editor title bar."
+        },
+        "nextflow.metro.path": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Path to the `nf-metro` executable. If empty, the extension looks for `nf-metro` on `PATH`."
+        },
+        "nextflow.metro.theme": {
+          "type": "string",
+          "enum": [
+            "nfcore",
+            "light",
+            "seqera"
+          ],
+          "default": "nfcore",
+          "markdownDescription": "Visual theme passed to [nf-metro](https://github.com/pinin4fjords/nf-metro) when rendering metro maps. `seqera` requires nf-metro 0.8+."
+        },
+        "nextflow.metro.format": {
+          "type": "string",
+          "enum": [
+            "html",
+            "svg"
+          ],
+          "default": "html",
+          "markdownDescription": "Output format for rendered metro maps: interactive `html` or static `svg`."
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 
 import { activateLanguageServer, stopLanguageServer } from "./languageServer";
+import { activateMetro } from "./metro";
 import { activateTelemetry, deactivateTelemetry } from "./telemetry";
 import { activateWebview } from "./webview";
 import { activateAuth, AuthProvider } from "./auth";
@@ -11,6 +12,7 @@ export function activate(context: vscode.ExtensionContext) {
   const authProvider = new AuthProvider(context);
   activateAuth(context, authProvider);
   activateLanguageServer(context, trackEvent);
+  activateMetro(context, trackEvent);
   activateWebview(context, authProvider);
   activateNextflowLog(context);
 }

--- a/src/metro/buildMetroWebview.ts
+++ b/src/metro/buildMetroWebview.ts
@@ -1,0 +1,43 @@
+import * as fs from "fs/promises";
+
+import type { MetroFormat } from "./types";
+
+function wrapSvg(svg: string): string {
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+      width: 100%;
+      height: 100%;
+      overflow: auto;
+      background: var(--vscode-editor-background, #ffffff);
+    }
+    svg {
+      max-width: 100%;
+      height: auto;
+      display: block;
+      margin: 0 auto;
+    }
+  </style>
+</head>
+<body>
+${svg}
+</body>
+</html>`;
+}
+
+export async function loadMetroWebviewContent(
+  filePath: string,
+  format: MetroFormat
+): Promise<string> {
+  const content = await fs.readFile(filePath, "utf8");
+  if (format === "html") {
+    return content;
+  }
+  return wrapSvg(content);
+}

--- a/src/metro/candidatePaths.ts
+++ b/src/metro/candidatePaths.ts
@@ -1,0 +1,24 @@
+import * as os from "os";
+import * as path from "path";
+
+export function getCandidateNfMetroPaths(): string[] {
+  const home = os.homedir();
+  const candidates = ["nf-metro"];
+
+  if (process.platform === "win32") {
+    candidates.push(
+      path.join(home, "AppData", "Roaming", "Python", "Scripts", "nf-metro.exe"),
+      path.join(home, ".local", "bin", "nf-metro.exe")
+    );
+  } else {
+    candidates.push(
+      path.join(home, ".local", "bin", "nf-metro"),
+      "/usr/local/bin/nf-metro",
+      path.join(home, "miniconda3", "bin", "nf-metro"),
+      path.join(home, "anaconda3", "bin", "nf-metro"),
+      path.join(home, "micromamba", "bin", "nf-metro")
+    );
+  }
+
+  return candidates;
+}

--- a/src/metro/detectMetroFile.ts
+++ b/src/metro/detectMetroFile.ts
@@ -1,0 +1,32 @@
+import type { MetroFileKind } from "./types";
+
+export function detectMetroFile(content: string, ext: string): MetroFileKind | undefined {
+  const lowerExt = ext.toLowerCase();
+
+  if (lowerExt === ".mmd") {
+    return content.includes("%%metro") ? "mmd" : undefined;
+  }
+
+  if (lowerExt === ".html") {
+    if (
+      content.includes("nf-metro") &&
+      (content.includes("<svg") || content.includes("data-nfm"))
+    ) {
+      return "html";
+    }
+    return undefined;
+  }
+
+  if (lowerExt === ".svg") {
+    if (
+      content.includes('script type="application/json"') ||
+      content.includes("data-node-") ||
+      content.includes("nf-metro")
+    ) {
+      return "svg";
+    }
+    return undefined;
+  }
+
+  return undefined;
+}

--- a/src/metro/detectMetroFile.ts
+++ b/src/metro/detectMetroFile.ts
@@ -1,10 +1,20 @@
 import type { MetroFileKind } from "./types";
 
+function isNextflowDag(content: string): boolean {
+  return /flowchart\s+TB/i.test(content) && /\(\["/.test(content);
+}
+
 export function detectMetroFile(content: string, ext: string): MetroFileKind | undefined {
   const lowerExt = ext.toLowerCase();
 
   if (lowerExt === ".mmd") {
-    return content.includes("%%metro") ? "mmd" : undefined;
+    if (content.includes("%%metro")) {
+      return "mmd";
+    }
+    if (isNextflowDag(content)) {
+      return "nextflow-dag";
+    }
+    return undefined;
   }
 
   if (lowerExt === ".html") {

--- a/src/metro/findMetroOutputs.ts
+++ b/src/metro/findMetroOutputs.ts
@@ -3,29 +3,19 @@ import * as path from "path";
 import * as vscode from "vscode";
 
 import { detectMetroFile } from "./detectMetroFile";
+import { parseOutputDirsFromConfig } from "./parseOutputDirs";
 
 const METRO_EXTENSIONS = new Set([".mmd", ".html", ".svg"]);
 const MAX_SCAN_DEPTH = 5;
 
 async function readOutputDirs(workspaceRoot: string): Promise<string[]> {
-  const dirs = new Set<string>([
-    path.join(workspaceRoot, "results"),
-    path.join(workspaceRoot, "output")
-  ]);
-
   const configPath = path.join(workspaceRoot, "nextflow.config");
   try {
     const config = await fs.readFile(configPath, "utf8");
-    const outdirMatch = config.match(/(?:outputDir|params\.outdir)\s*=\s*['"]([^'"]+)['"]/);
-    if (outdirMatch?.[1]) {
-      const outdir = outdirMatch[1];
-      dirs.add(path.isAbsolute(outdir) ? outdir : path.join(workspaceRoot, outdir));
-    }
+    return parseOutputDirsFromConfig(config, workspaceRoot);
   } catch {
-    // nextflow.config may not exist
+    return parseOutputDirsFromConfig("", workspaceRoot);
   }
-
-  return [...dirs];
 }
 
 async function scanDir(dir: string, found: string[], depth = 0): Promise<void> {

--- a/src/metro/findMetroOutputs.ts
+++ b/src/metro/findMetroOutputs.ts
@@ -1,0 +1,84 @@
+import * as fs from "fs/promises";
+import * as path from "path";
+import * as vscode from "vscode";
+
+import { detectMetroFile } from "./detectMetroFile";
+
+const METRO_EXTENSIONS = new Set([".mmd", ".html", ".svg"]);
+const MAX_SCAN_DEPTH = 5;
+
+async function readOutputDirs(workspaceRoot: string): Promise<string[]> {
+  const dirs = new Set<string>([
+    path.join(workspaceRoot, "results"),
+    path.join(workspaceRoot, "output")
+  ]);
+
+  const configPath = path.join(workspaceRoot, "nextflow.config");
+  try {
+    const config = await fs.readFile(configPath, "utf8");
+    const outdirMatch = config.match(/(?:outputDir|params\.outdir)\s*=\s*['"]([^'"]+)['"]/);
+    if (outdirMatch?.[1]) {
+      const outdir = outdirMatch[1];
+      dirs.add(path.isAbsolute(outdir) ? outdir : path.join(workspaceRoot, outdir));
+    }
+  } catch {
+    // nextflow.config may not exist
+  }
+
+  return [...dirs];
+}
+
+async function scanDir(dir: string, found: string[], depth = 0): Promise<void> {
+  if (depth > MAX_SCAN_DEPTH) {
+    return;
+  }
+
+  let entries;
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await scanDir(fullPath, found, depth + 1);
+      continue;
+    }
+    if (!entry.isFile()) {
+      continue;
+    }
+
+    const ext = path.extname(entry.name).toLowerCase();
+    if (!METRO_EXTENSIONS.has(ext)) {
+      continue;
+    }
+
+    try {
+      const content = await fs.readFile(fullPath, "utf8");
+      if (detectMetroFile(content, ext)) {
+        found.push(fullPath);
+      }
+    } catch {
+      // skip unreadable files
+    }
+  }
+}
+
+export async function findMetroOutputs(): Promise<string[]> {
+  const workspaceFolders = vscode.workspace.workspaceFolders;
+  if (!workspaceFolders?.length) {
+    return [];
+  }
+
+  const found: string[] = [];
+  for (const folder of workspaceFolders) {
+    const dirs = await readOutputDirs(folder.uri.fsPath);
+    for (const dir of dirs) {
+      await scanDir(dir, found);
+    }
+  }
+
+  return [...new Set(found)].sort((a, b) => a.localeCompare(b));
+}

--- a/src/metro/findNfMetro.ts
+++ b/src/metro/findNfMetro.ts
@@ -2,6 +2,7 @@ import * as cp from "child_process";
 import * as fs from "fs";
 import * as vscode from "vscode";
 
+import { getCandidateNfMetroPaths } from "./candidatePaths";
 import type { MetroConfig } from "./types";
 
 const INSTALL_HINT =
@@ -23,12 +24,7 @@ export function getMetroConfig(): MetroConfig {
   };
 }
 
-export async function findNfMetro(): Promise<string | undefined> {
-  const { path: configuredPath } = getMetroConfig();
-  if (configuredPath) {
-    return fs.existsSync(configuredPath) ? configuredPath : undefined;
-  }
-
+function findOnPath(): Promise<string | undefined> {
   const lookup = process.platform === "win32" ? "where nf-metro" : "which nf-metro";
   return new Promise((resolve) => {
     cp.exec(lookup, (error, stdout) => {
@@ -39,6 +35,29 @@ export async function findNfMetro(): Promise<string | undefined> {
       resolve(stdout.trim().split(/\r?\n/)[0]);
     });
   });
+}
+
+function findInCandidatePaths(): string | undefined {
+  for (const candidate of getCandidateNfMetroPaths()) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+export async function findNfMetro(): Promise<string | undefined> {
+  const { path: configuredPath } = getMetroConfig();
+  if (configuredPath) {
+    return fs.existsSync(configuredPath) ? configuredPath : undefined;
+  }
+
+  const onPath = await findOnPath();
+  if (onPath) {
+    return onPath;
+  }
+
+  return findInCandidatePaths();
 }
 
 export async function requireNfMetro(): Promise<string> {

--- a/src/metro/findNfMetro.ts
+++ b/src/metro/findNfMetro.ts
@@ -1,0 +1,62 @@
+import * as cp from "child_process";
+import * as fs from "fs";
+import * as vscode from "vscode";
+
+import type { MetroConfig } from "./types";
+
+const INSTALL_HINT =
+  "Install nf-metro with: pip install nf-metro  or  conda install bioconda::nf-metro";
+
+export class NfMetroNotFoundError extends Error {
+  constructor() {
+    super("nf-metro not found");
+    this.name = "NfMetroNotFoundError";
+  }
+}
+
+export function getMetroConfig(): MetroConfig {
+  const config = vscode.workspace.getConfiguration("nextflow.metro");
+  return {
+    path: config.get<string>("path", ""),
+    theme: config.get<MetroConfig["theme"]>("theme", "nfcore"),
+    format: config.get<MetroConfig["format"]>("format", "html")
+  };
+}
+
+export async function findNfMetro(): Promise<string | undefined> {
+  const { path: configuredPath } = getMetroConfig();
+  if (configuredPath) {
+    return fs.existsSync(configuredPath) ? configuredPath : undefined;
+  }
+
+  const lookup = process.platform === "win32" ? "where nf-metro" : "which nf-metro";
+  return new Promise((resolve) => {
+    cp.exec(lookup, (error, stdout) => {
+      if (error || !stdout.trim()) {
+        resolve(undefined);
+        return;
+      }
+      resolve(stdout.trim().split(/\r?\n/)[0]);
+    });
+  });
+}
+
+export async function requireNfMetro(): Promise<string> {
+  const nfMetro = await findNfMetro();
+  if (!nfMetro) {
+    throw new NfMetroNotFoundError();
+  }
+  return nfMetro;
+}
+
+export function showNfMetroNotFound(): void {
+  void vscode.window
+    .showErrorMessage(`nf-metro was not found. ${INSTALL_HINT}`, "Open PyPI")
+    .then((action) => {
+      if (action === "Open PyPI") {
+        void vscode.env.openExternal(
+          vscode.Uri.parse("https://pypi.org/project/nf-metro/")
+        );
+      }
+    });
+}

--- a/src/metro/index.ts
+++ b/src/metro/index.ts
@@ -1,0 +1,24 @@
+import * as vscode from "vscode";
+
+import { findAndOpenMetroOutputs, openMetroFile } from "./openMetroFile";
+import { previewMetro } from "./previewMetro";
+import type { TrackEvent } from "../telemetry";
+
+export function activateMetro(
+  context: vscode.ExtensionContext,
+  trackEvent: TrackEvent
+): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "nextflow.previewMetro",
+      (uri?: string, name?: string) => previewMetro(context, uri, name, trackEvent)
+    ),
+    vscode.commands.registerCommand(
+      "nextflow.openMetroFile",
+      (uri?: vscode.Uri) => openMetroFile(context, uri, trackEvent)
+    ),
+    vscode.commands.registerCommand("nextflow.findMetroOutputs", () =>
+      findAndOpenMetroOutputs(context, trackEvent)
+    )
+  );
+}

--- a/src/metro/index.ts
+++ b/src/metro/index.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 
 import { findAndOpenMetroOutputs, openMetroFile } from "./openMetroFile";
+import { getMetroOutputChannel } from "./outputChannel";
 import { previewMetro } from "./previewMetro";
 import type { TrackEvent } from "../telemetry";
 
@@ -19,6 +20,7 @@ export function activateMetro(
     ),
     vscode.commands.registerCommand("nextflow.findMetroOutputs", () =>
       findAndOpenMetroOutputs(context, trackEvent)
-    )
+    ),
+    getMetroOutputChannel()
   );
 }

--- a/src/metro/metro.test.ts
+++ b/src/metro/metro.test.ts
@@ -1,0 +1,52 @@
+import { strict as assert } from "node:assert";
+import { describe, it } from "node:test";
+
+import { detectMetroFile } from "./detectMetroFile.ts";
+import { parseOutputDirsFromConfig } from "./parseOutputDirs.ts";
+
+describe("detectMetroFile", () => {
+  it("detects nf-metro mmd files", () => {
+    assert.equal(detectMetroFile("%%metro title: test\ngraph LR", ".mmd"), "mmd");
+  });
+
+  it("detects nextflow dag mmd files", () => {
+    const dag = `flowchart TB
+    v0(["FASTQC"])
+    v1(["TRIM"])
+    v0 --> v1`;
+    assert.equal(detectMetroFile(dag, ".mmd"), "nextflow-dag");
+  });
+
+  it("detects nf-metro html files", () => {
+    const html = '<html><div class="nf-metro-canvas"><svg></svg></div></html>';
+    assert.equal(detectMetroFile(html, ".html"), "html");
+  });
+
+  it("detects nf-metro svg files", () => {
+    const svg = '<svg data-node-id="fastqc"><script type="application/json">{}</script></svg>';
+    assert.equal(detectMetroFile(svg, ".svg"), "svg");
+  });
+
+  it("rejects unrelated files", () => {
+    assert.equal(detectMetroFile("<html></html>", ".html"), undefined);
+    assert.equal(detectMetroFile("graph LR\na --> b", ".mmd"), undefined);
+  });
+});
+
+describe("parseOutputDirsFromConfig", () => {
+  it("includes default output directories", () => {
+    const dirs = parseOutputDirsFromConfig("", "/workspace/pipeline");
+    assert.ok(dirs.includes("/workspace/pipeline/results"));
+    assert.ok(dirs.includes("/workspace/pipeline/output"));
+  });
+
+  it("parses outputDir and params.outdir", () => {
+    const config = `
+      outputDir = 'custom-results'
+      params.outdir = 'legacy-results'
+    `;
+    const dirs = parseOutputDirsFromConfig(config, "/workspace/pipeline");
+    assert.ok(dirs.includes("/workspace/pipeline/custom-results"));
+    assert.ok(dirs.includes("/workspace/pipeline/legacy-results"));
+  });
+});

--- a/src/metro/openMetroFile.ts
+++ b/src/metro/openMetroFile.ts
@@ -1,0 +1,111 @@
+import * as fs from "fs/promises";
+import * as path from "path";
+import * as vscode from "vscode";
+
+import { detectMetroFile } from "./detectMetroFile";
+import {
+  NfMetroNotFoundError,
+  showNfMetroNotFound
+} from "./findNfMetro";
+import { findMetroOutputs } from "./findMetroOutputs";
+import { logMetroMessage } from "./outputChannel";
+import { openMetroWebview } from "./openMetroWebview";
+import { renderMetroFile } from "./renderFromDag";
+import type { TrackEvent } from "../telemetry";
+
+async function previewMetroArtifact(
+  filePath: string,
+  context: vscode.ExtensionContext,
+  trackEvent?: TrackEvent
+): Promise<void> {
+  const content = await fs.readFile(filePath, "utf8");
+  const ext = path.extname(filePath);
+  const kind = detectMetroFile(content, ext);
+
+  if (!kind) {
+    vscode.window.showErrorMessage("This file does not appear to be an nf-metro output.");
+    return;
+  }
+
+  const title = path.basename(filePath);
+
+  if (kind === "mmd") {
+    try {
+      await vscode.window.withProgress(
+        {
+          location: vscode.ProgressLocation.Notification,
+          title: "Rendering metro map..."
+        },
+        async () => {
+          const { outputPath, format } = await renderMetroFile(
+            filePath,
+            context,
+            path.basename(filePath, ext)
+          );
+          await openMetroWebview(
+            title,
+            outputPath,
+            format,
+            trackEvent,
+            "openMetroFile"
+          );
+        }
+      );
+    } catch (error) {
+      if (error instanceof NfMetroNotFoundError) {
+        showNfMetroNotFound();
+        return;
+      }
+
+      const message = error instanceof Error ? error.message : String(error);
+      logMetroMessage(message);
+      vscode.window.showErrorMessage(`Failed to render metro map: ${message}`);
+    }
+    return;
+  }
+
+  await openMetroWebview(title, filePath, kind, trackEvent, "openMetroFile");
+}
+
+export async function openMetroFile(
+  context: vscode.ExtensionContext,
+  uri?: vscode.Uri,
+  trackEvent?: TrackEvent
+): Promise<void> {
+  const fileUri = uri ?? vscode.window.activeTextEditor?.document.uri;
+  if (!fileUri) {
+    return;
+  }
+
+  await previewMetroArtifact(fileUri.fsPath, context, trackEvent);
+}
+
+export async function findAndOpenMetroOutputs(
+  context: vscode.ExtensionContext,
+  trackEvent?: TrackEvent
+): Promise<void> {
+  const outputs = await findMetroOutputs();
+  if (outputs.length === 0) {
+    vscode.window.showInformationMessage(
+      "No nf-metro outputs found in common pipeline output directories."
+    );
+    return;
+  }
+
+  const selection = await vscode.window.showQuickPick(
+    outputs.map((filePath) => ({
+      label: path.basename(filePath),
+      description: path.dirname(filePath),
+      filePath
+    })),
+    {
+      placeHolder: "Select an nf-metro output to preview"
+    }
+  );
+
+  if (!selection) {
+    return;
+  }
+
+  await previewMetroArtifact(selection.filePath, context, trackEvent);
+}

--- a/src/metro/openMetroFile.ts
+++ b/src/metro/openMetroFile.ts
@@ -29,7 +29,7 @@ async function previewMetroArtifact(
 
   const title = path.basename(filePath);
 
-  if (kind === "mmd") {
+  if (kind === "mmd" || kind === "nextflow-dag") {
     try {
       await vscode.window.withProgress(
         {
@@ -40,7 +40,8 @@ async function previewMetroArtifact(
           const { outputPath, format } = await renderMetroFile(
             filePath,
             context,
-            path.basename(filePath, ext)
+            path.basename(filePath, ext),
+            kind === "nextflow-dag"
           );
           await openMetroWebview(
             title,

--- a/src/metro/openMetroWebview.ts
+++ b/src/metro/openMetroWebview.ts
@@ -1,0 +1,29 @@
+import * as vscode from "vscode";
+
+import { loadMetroWebviewContent } from "./buildMetroWebview";
+import type { MetroFormat } from "./types";
+import type { TrackEvent } from "../telemetry";
+
+export async function openMetroWebview(
+  title: string,
+  filePath: string,
+  format: MetroFormat,
+  trackEvent?: TrackEvent,
+  eventName?: string
+): Promise<void> {
+  const panel = vscode.window.createWebviewPanel(
+    "metro-preview",
+    title,
+    vscode.ViewColumn.Beside,
+    {
+      enableScripts: true,
+      retainContextWhenHidden: true
+    }
+  );
+
+  panel.webview.html = await loadMetroWebviewContent(filePath, format);
+
+  if (trackEvent && eventName) {
+    trackEvent(eventName, { format });
+  }
+}

--- a/src/metro/outputChannel.ts
+++ b/src/metro/outputChannel.ts
@@ -1,0 +1,16 @@
+import * as vscode from "vscode";
+
+const CHANNEL_NAME = "Nextflow Metro";
+
+let outputChannel: vscode.OutputChannel | undefined;
+
+export function getMetroOutputChannel(): vscode.OutputChannel {
+  if (!outputChannel) {
+    outputChannel = vscode.window.createOutputChannel(CHANNEL_NAME);
+  }
+  return outputChannel;
+}
+
+export function logMetroMessage(message: string): void {
+  getMetroOutputChannel().appendLine(message);
+}

--- a/src/metro/parseOutputDirs.ts
+++ b/src/metro/parseOutputDirs.ts
@@ -1,0 +1,27 @@
+import * as path from "path";
+
+export function parseOutputDirsFromConfig(
+  config: string,
+  workspaceRoot: string
+): string[] {
+  const dirs = new Set<string>([
+    path.join(workspaceRoot, "results"),
+    path.join(workspaceRoot, "output")
+  ]);
+
+  const patterns = [
+    /(?:^|\n)\s*outputDir\s*=\s*['"]([^'"]+)['"]/m,
+    /(?:^|\n)\s*params\.outdir\s*=\s*['"]([^'"]+)['"]/m,
+    /(?:^|\n)\s*outdir\s*=\s*['"]([^'"]+)['"]/m
+  ];
+
+  for (const pattern of patterns) {
+    const match = config.match(pattern);
+    if (match?.[1]) {
+      const outdir = match[1];
+      dirs.add(path.isAbsolute(outdir) ? outdir : path.join(workspaceRoot, outdir));
+    }
+  }
+
+  return [...dirs];
+}

--- a/src/metro/previewMetro.ts
+++ b/src/metro/previewMetro.ts
@@ -1,0 +1,77 @@
+import * as path from "path";
+import * as vscode from "vscode";
+
+import {
+  NfMetroNotFoundError,
+  showNfMetroNotFound
+} from "./findNfMetro";
+import { logMetroMessage } from "./outputChannel";
+import { openMetroWebview } from "./openMetroWebview";
+import { renderFromDag } from "./renderFromDag";
+import type { TrackEvent } from "../telemetry";
+
+async function fetchDagContent(
+  uri: string,
+  name?: string
+): Promise<string | undefined> {
+  const res: { result?: string; error?: string } | undefined =
+    await vscode.commands.executeCommand("nextflow.server.previewDag", uri, name);
+
+  if (!res?.result) {
+    vscode.window.showErrorMessage(res?.error ?? "Failed to render DAG preview.");
+    return undefined;
+  }
+
+  return res.result;
+}
+
+export async function previewMetro(
+  context: vscode.ExtensionContext,
+  uri?: string,
+  name?: string,
+  trackEvent?: TrackEvent
+): Promise<void> {
+  const docUri = uri ?? vscode.window.activeTextEditor?.document.uri.toString();
+  if (!docUri) {
+    return;
+  }
+
+  const dagContent = await fetchDagContent(docUri, name);
+  if (!dagContent) {
+    return;
+  }
+
+  const title = name ?? path.basename(docUri, path.extname(docUri));
+
+  try {
+    await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: "Rendering metro map..."
+      },
+      async () => {
+        const { outputPath, format } = await renderFromDag(
+          dagContent,
+          title,
+          context
+        );
+        await openMetroWebview(
+          `${title} metro map`,
+          outputPath,
+          format,
+          trackEvent,
+          "previewMetro"
+        );
+      }
+    );
+  } catch (error) {
+    if (error instanceof NfMetroNotFoundError) {
+      showNfMetroNotFound();
+      return;
+    }
+
+    const message = error instanceof Error ? error.message : String(error);
+    logMetroMessage(message);
+    vscode.window.showErrorMessage(`Failed to render metro map: ${message}`);
+  }
+}

--- a/src/metro/renderFromDag.ts
+++ b/src/metro/renderFromDag.ts
@@ -1,0 +1,96 @@
+import * as cp from "child_process";
+import * as fs from "fs/promises";
+import * as path from "path";
+import * as vscode from "vscode";
+
+import { getMetroConfig, requireNfMetro } from "./findNfMetro";
+import { logMetroMessage } from "./outputChannel";
+import type { MetroFormat, RenderResult } from "./types";
+
+function execNfMetro(
+  command: string,
+  args: string[]
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    cp.execFile(command, args, { maxBuffer: 10 * 1024 * 1024 }, (error, stdout, stderr) => {
+      if (error) {
+        const message = stderr.trim() || stdout.trim() || error.message;
+        reject(new Error(message));
+        return;
+      }
+      resolve({ stdout, stderr });
+    });
+  });
+}
+
+async function createTempDir(context: vscode.ExtensionContext): Promise<string> {
+  const tmpDir = path.join(
+    context.globalStorageUri.fsPath,
+    "metro-tmp",
+    Date.now().toString()
+  );
+  await fs.mkdir(tmpDir, { recursive: true });
+  return tmpDir;
+}
+
+async function renderWithNfMetro(
+  inputPath: string,
+  outputPath: string,
+  options: { fromNextflow: boolean; title?: string }
+): Promise<RenderResult> {
+  const nfMetro = await requireNfMetro();
+  const { theme, format } = getMetroConfig();
+
+  const args = [
+    "render",
+    inputPath,
+    "-o",
+    outputPath,
+    "--format",
+    format,
+    "--theme",
+    theme
+  ];
+
+  if (options.fromNextflow) {
+    args.push("--from-nextflow");
+  }
+  if (options.title) {
+    args.push("--title", options.title);
+  }
+
+  const { stderr } = await execNfMetro(nfMetro, args);
+  if (stderr.trim()) {
+    logMetroMessage(stderr.trim());
+  }
+
+  return { outputPath, format };
+}
+
+export async function renderFromDag(
+  dagContent: string,
+  title: string,
+  context: vscode.ExtensionContext
+): Promise<RenderResult> {
+  const { format } = getMetroConfig();
+  const tmpDir = await createTempDir(context);
+  const dagFile = path.join(tmpDir, "dag.mmd");
+  const outputFile = path.join(tmpDir, `metro.${format === "html" ? "html" : "svg"}`);
+
+  await fs.writeFile(dagFile, dagContent, "utf8");
+  return renderWithNfMetro(dagFile, outputFile, { fromNextflow: true, title });
+}
+
+export async function renderMetroFile(
+  inputPath: string,
+  context: vscode.ExtensionContext,
+  title?: string
+): Promise<RenderResult> {
+  const { format } = getMetroConfig();
+  const tmpDir = await createTempDir(context);
+  const outputFile = path.join(tmpDir, `metro.${format === "html" ? "html" : "svg"}`);
+  return renderWithNfMetro(inputPath, outputFile, {
+    fromNextflow: false,
+    title: title ?? path.basename(inputPath, path.extname(inputPath))
+  });
+}

--- a/src/metro/renderFromDag.ts
+++ b/src/metro/renderFromDag.ts
@@ -84,13 +84,14 @@ export async function renderFromDag(
 export async function renderMetroFile(
   inputPath: string,
   context: vscode.ExtensionContext,
-  title?: string
+  title?: string,
+  fromNextflow = false
 ): Promise<RenderResult> {
   const { format } = getMetroConfig();
   const tmpDir = await createTempDir(context);
   const outputFile = path.join(tmpDir, `metro.${format === "html" ? "html" : "svg"}`);
   return renderWithNfMetro(inputPath, outputFile, {
-    fromNextflow: false,
+    fromNextflow,
     title: title ?? path.basename(inputPath, path.extname(inputPath))
   });
 }

--- a/src/metro/smoke.integration.ts
+++ b/src/metro/smoke.integration.ts
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/**
+ * Integration smoke test for nf-metro extension logic.
+ * Exercises the same pure functions and CLI calls the extension uses,
+ * without requiring the VS Code host.
+ */
+import { strict as assert } from "node:assert";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { getCandidateNfMetroPaths } from "./candidatePaths.ts";
+import { detectMetroFile } from "./detectMetroFile.ts";
+import { parseOutputDirsFromConfig } from "./parseOutputDirs.ts";
+
+const FIXTURE_ROOT = process.env.METRO_SMOKE_ROOT ?? "/tmp/nf-metro-smoke";
+
+function readFixture(relPath: string): string {
+  return fs.readFileSync(path.join(FIXTURE_ROOT, relPath), "utf8");
+}
+
+function findNfMetroWithoutPath(): string | undefined {
+  for (const candidate of getCandidateNfMetroPaths()) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+function scanMetroOutputs(workspaceRoot: string): string[] {
+  const config = fs.readFileSync(path.join(workspaceRoot, "nextflow.config"), "utf8");
+  const dirs = parseOutputDirsFromConfig(config, workspaceRoot);
+  const found: string[] = [];
+  const extensions = new Set([".mmd", ".html", ".svg"]);
+
+  function scan(dir: string, depth = 0) {
+    if (depth > 5) return;
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        scan(fullPath, depth + 1);
+        continue;
+      }
+      const ext = path.extname(entry.name).toLowerCase();
+      if (!extensions.has(ext)) continue;
+      const content = fs.readFileSync(fullPath, "utf8");
+      if (detectMetroFile(content, ext)) {
+        found.push(fullPath);
+      }
+    }
+  }
+
+  for (const dir of dirs) {
+    scan(dir);
+  }
+  return [...new Set(found)].sort();
+}
+
+function main() {
+  console.log("nf-metro integration smoke test\n");
+
+  // 1. File detection
+  const dag = readFixture("dag.mmd");
+  assert.equal(detectMetroFile(dag, ".mmd"), "nextflow-dag", "dag.mmd detection");
+  assert.equal(
+    detectMetroFile(readFixture("results/metro_map.html"), ".html"),
+    "html",
+    "html detection"
+  );
+  assert.equal(
+    detectMetroFile(readFixture("results/pipeline.mmd"), ".mmd"),
+    "mmd",
+    "metro mmd detection"
+  );
+  console.log("✓ detectMetroFile");
+
+  // 2. Output dir parsing
+  const config = readFixture("nextflow.config");
+  const dirs = parseOutputDirsFromConfig(config, FIXTURE_ROOT);
+  assert.ok(dirs.includes(path.join(FIXTURE_ROOT, "results")));
+  assert.ok(dirs.includes(path.join(FIXTURE_ROOT, "custom-out")));
+  console.log("✓ parseOutputDirsFromConfig");
+
+  // 3. Output scanning (simulates findMetroOutputs)
+  const outputs = scanMetroOutputs(FIXTURE_ROOT);
+  assert.equal(outputs.length, 2, `expected 2 outputs, got ${outputs.length}: ${outputs}`);
+  console.log("✓ scanMetroOutputs ->", outputs.map((p) => path.basename(p)).join(", "));
+
+  // 4. CLI discovery without PATH
+  const nfMetro = findNfMetroWithoutPath();
+  assert.ok(nfMetro, "nf-metro should be discoverable via candidate paths");
+  console.log("✓ findNfMetro candidate path ->", nfMetro);
+
+  // 5. Render --from-nextflow (simulates previewMetro)
+  const dagOut = path.join(FIXTURE_ROOT, "rendered-from-dag.html");
+  execFileSync(
+    nfMetro,
+    [
+      "render",
+      path.join(FIXTURE_ROOT, "dag.mmd"),
+      "-o",
+      dagOut,
+      "--from-nextflow",
+      "--format",
+      "html",
+      "--theme",
+      "nfcore",
+      "--title",
+      "Smoke DAG"
+    ],
+    { stdio: "pipe" }
+  );
+  assert.ok(fs.existsSync(dagOut), "dag render output missing");
+  assert.ok(fs.statSync(dagOut).size > 1000, "dag render output too small");
+  console.log("✓ nf-metro render --from-nextflow ->", dagOut);
+
+  // 6. Render curated mmd (simulates openMetroFile on .mmd)
+  const mmdOut = path.join(FIXTURE_ROOT, "rendered-from-mmd.html");
+  execFileSync(
+    nfMetro,
+    [
+      "render",
+      path.join(FIXTURE_ROOT, "results/pipeline.mmd"),
+      "-o",
+      mmdOut,
+      "--format",
+      "html",
+      "--theme",
+      "nfcore"
+    ],
+    { stdio: "pipe" }
+  );
+  assert.ok(fs.existsSync(mmdOut), "mmd render output missing");
+  console.log("✓ nf-metro render curated .mmd ->", mmdOut);
+
+  // 7. Pre-rendered html loads (simulates openMetroFile on .html)
+  const html = fs.readFileSync(path.join(FIXTURE_ROOT, "results/metro_map.html"), "utf8");
+  assert.equal(detectMetroFile(html, ".html"), "html");
+  console.log("✓ pre-rendered html open path");
+
+  console.log("\nAll integration smoke checks passed.");
+}
+
+main();

--- a/src/metro/types.ts
+++ b/src/metro/types.ts
@@ -1,0 +1,14 @@
+export type MetroTheme = "nfcore" | "light" | "seqera";
+export type MetroFormat = "html" | "svg";
+export type MetroFileKind = "mmd" | "html" | "svg";
+
+export interface MetroConfig {
+  path: string;
+  theme: MetroTheme;
+  format: MetroFormat;
+}
+
+export interface RenderResult {
+  outputPath: string;
+  format: MetroFormat;
+}

--- a/src/metro/types.ts
+++ b/src/metro/types.ts
@@ -1,6 +1,6 @@
 export type MetroTheme = "nfcore" | "light" | "seqera";
 export type MetroFormat = "html" | "svg";
-export type MetroFileKind = "mmd" | "html" | "svg";
+export type MetroFileKind = "mmd" | "html" | "svg" | "nextflow-dag";
 
 export interface MetroConfig {
   path: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,5 @@
     "rootDir": "src",
     "types": []
   },
-  "exclude": ["node_modules", ".vscode-test", "webview-ui", "src/**/*.test.ts"]
+  "exclude": ["node_modules", ".vscode-test", "webview-ui", "src/**/*.test.ts", "src/**/*.integration.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,5 @@
     "rootDir": "src",
     "types": []
   },
-  "exclude": ["node_modules", ".vscode-test", "webview-ui"]
+  "exclude": ["node_modules", ".vscode-test", "webview-ui", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds integration with [nf-metro](https://github.com/pinin4fjords/nf-metro) to the Nextflow VS Code extension:

- **Preview Metro Map** (`nextflow.previewMetro`) — fetches the workflow DAG from the language server and renders a metro map via `nf-metro render --from-nextflow`
- **Open Metro Map Preview** (`nextflow.openMetroFile`) — opens pre-rendered `.html`, `.svg`, `.mmd` nf-metro files, or Nextflow `-with-dag` `.mmd` exports
- **Find Metro Map Outputs** (`nextflow.findMetroOutputs`) — scans common pipeline output directories (`results/`, `output/`, and `outputDir` from `nextflow.config`) for nf-metro artifacts

New settings under `nextflow.metro.*`:
- `path` — explicit `nf-metro` executable (defaults to `PATH` lookup plus common pip/conda install paths)
- `theme` — `nfcore`, `light`, or `seqera` (default `nfcore`; `seqera` requires nf-metro 0.8+)
- `format` — `html` (interactive) or `svg` (default `html`)

## Test plan

- [x] `npm test` passes (7 unit tests for file detection and output-dir parsing)
- [x] `npm run check-types` passes
- [x] `npm run compile` passes
- [x] `detectMetroFile` verified against rendered nf-metro HTML and Nextflow DAG mmd
- [x] `nf-metro render --from-nextflow` smoke-tested with nf-metro 0.7.2
- [x] CLI discovery finds `~/.local/bin/nf-metro` when not on PATH
- [ ] Manual: open a `.nf` workflow → **Preview Metro Map** (requires nf-metro)
- [ ] Manual: open nf-metro `.html`/`.svg` from `results/` → **Open Metro Map Preview**
- [ ] Manual: open a `-with-dag` `.mmd` export → renders via `--from-nextflow`
- [ ] Manual: **Find Metro Map Outputs** in a pipeline workspace with published metro artifacts

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a65a3b1-de93-477c-876f-786a198c36be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a65a3b1-de93-477c-876f-786a198c36be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

