### PR TITLE
Add CI workflow running format, lint, type check and build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -15,9 +18,11 @@ jobs:
     name: Prettier
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
           cache: "npm"
@@ -32,9 +37,11 @@ jobs:
     name: ESLint (webview-ui)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
           cache: "npm"
@@ -52,9 +59,11 @@ jobs:
     name: Type check & build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
           cache: "npm"
@@ -71,7 +80,7 @@ jobs:
         run: npm run package
 
       - name: Upload extension artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nextflow-vsix
           path: build/nextflow.vsix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,77 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  format:
+    name: Prettier
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+
+      - name: npm clean install
+        run: npm ci
+
+      - name: Check formatting
+        run: npx prettier --check .
+
+  lint:
+    name: ESLint (webview-ui)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+          cache-dependency-path: webview-ui/package-lock.json
+
+      - name: npm clean install
+        run: npm ci
+        working-directory: webview-ui
+
+      - name: Lint
+        run: npm run lint
+        working-directory: webview-ui
+
+  build:
+    name: Type check & build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+
+      - name: npm clean install
+        run: |
+          (cd webview-ui ; npm ci)
+          npm ci
+
+      - name: Type check
+        run: npm run check-types
+
+      - name: Build vscode extension
+        run: npm run package
+
+      - name: Upload extension artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: nextflow-vsix
+          path: build/nextflow.vsix

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,11 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       vscode_marketplace:
-        description: 'Publish to Visual Studio Marketplace'
+        description: "Publish to Visual Studio Marketplace"
         type: boolean
         default: true
       open_vsx:
-        description: 'Publish to Open VSX Registry'
+        description: "Publish to Open VSX Registry"
         type: boolean
         default: true
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,13 +12,23 @@ on:
         type: boolean
         default: true
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
+    name: Publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
           cache: "npm"
@@ -33,7 +43,7 @@ jobs:
 
       - name: Publish to Visual Studio Marketplace
         if: ${{ github.event.inputs.vscode_marketplace == 'true' }}
-        uses: HaaLeo/publish-vscode-extension@v1
+        uses: HaaLeo/publish-vscode-extension@ca5561daa085dee804bf9f37fe0165785a9b14db # v2.0.0
         with:
           pat: ${{ secrets.VSCE_TOKEN }}
           registryUrl: https://marketplace.visualstudio.com
@@ -41,7 +51,7 @@ jobs:
 
       - name: Publish to Open VSX Registry
         if: ${{ github.event.inputs.open_vsx == 'true' }}
-        uses: HaaLeo/publish-vscode-extension@v1
+        uses: HaaLeo/publish-vscode-extension@ca5561daa085dee804bf9f37fe0165785a9b14db # v2.0.0
         with:
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
           extensionFile: build/nextflow.vsix

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 # Ignore artifacts:
 build
 coverage
+dist

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The tree view shows processes and workflows organized by call hierarchy:
 
 ![Project Tree View](images/project_view_tree.png)
 
-*Examples taken from the [nf-core/fetchngs](https://github.com/nf-core/fetchngs) pipeline.*
+_Examples taken from the [nf-core/fetchngs](https://github.com/nf-core/fetchngs) pipeline._
 
 The Project view allows you to:
 
@@ -58,7 +58,7 @@ This extension is available in the [Visual Studio Marketplace](https://marketpla
 
 The language server requires Java 17 or later.
 
-*Note: for custom Java installations such as conda, you might need to set the `nextflow.java.home` extension setting for the extension to find your Java installation.*
+_Note: for custom Java installations such as conda, you might need to set the `nextflow.java.home` extension setting for the extension to find your Java installation._
 
 ### Offline usage
 
@@ -71,7 +71,7 @@ wget https://github.com/nextflow-io/language-server/releases/download/v24.10.0/l
 
 The extension will fall back to the latest patch version from the local cache if it can't download from GitHub.
 
-*Note: Nextflow language server patch versions have no correlation to Nextflow patch versions. Always use the latest patch version of the language server when downloading a release manually.*
+_Note: Nextflow language server patch versions have no correlation to Nextflow patch versions. Always use the latest patch version of the language server when downloading a release manually._
 
 ## Commands
 
@@ -93,7 +93,7 @@ The following settings are available:
 
 - `nextflow.formatting.harshilAlignment`: Use the [Harshil Alignment™️](https://nf-co.re/docs/contributing/code_editors_and_styling/harshil_alignment) when formatting Nextflow scripts and config files.
 
-  *Note: not all rules are supported.*
+  _Note: not all rules are supported._
 
 - `nextflow.formatting.maheshForm`: Place process outputs at the end of the process body when formatting Nextflow scripts.
 

--- a/package.json
+++ b/package.json
@@ -295,7 +295,7 @@
         "nextflow.log.debugOpacity": {
           "type": "number",
           "minimum": 0.1,
-          "maximum": 1.0,
+          "maximum": 1,
           "default": 0.3,
           "markdownDescription": "Opacity applied to `DEBUG` and `TRACE` entries in `.nextflow.log` files. Set to `1.0` to disable dimming."
         },

--- a/src/languageServer/index.ts
+++ b/src/languageServer/index.ts
@@ -44,8 +44,7 @@ function startLanguageServer(context: vscode.ExtensionContext) {
             );
             return;
           }
-        }
-        catch (e) {
+        } catch (e) {
           console.warn(`Failed to check Java version: ${e}`);
         }
         progress.report({
@@ -106,11 +105,12 @@ function startLanguageServer(context: vscode.ExtensionContext) {
   );
 }
 
-async function previewDag(context: vscode.ExtensionContext, uri: string, name?: string) {
-  const mediaPath = vscode.Uri.joinPath(
-    context.extensionUri,
-    "media"
-  );
+async function previewDag(
+  context: vscode.ExtensionContext,
+  uri: string,
+  name?: string
+) {
+  const mediaPath = vscode.Uri.joinPath(context.extensionUri, "media");
   const res: any = await vscode.commands.executeCommand(
     "nextflow.server.previewDag",
     uri,
@@ -143,12 +143,13 @@ async function convertScriptToTyped() {
     .getConfiguration("nextflow")
     .get("languageVersion") as string;
   if (languageVersion === "24.10" || languageVersion == "25.04") {
-    vscode.window.showErrorMessage("The Nextflow language version must be 25.10 or newer in order to convert to static types.");
+    vscode.window.showErrorMessage(
+      "The Nextflow language version must be 25.10 or newer in order to convert to static types."
+    );
     return;
   }
   const uri = vscode.window.activeTextEditor?.document?.uri;
-  if (!uri)
-    return;
+  if (!uri) return;
 
   const res: any = await vscode.commands.executeCommand(
     "nextflow.server.convertScriptToTyped",
@@ -157,9 +158,10 @@ async function convertScriptToTyped() {
   if (!res || res.error) {
     const message = res?.error ?? "Failed to convert script to static types.";
     vscode.window.showErrorMessage(message);
-  }
-  else {
-    vscode.window.showInformationMessage("Converted script to static types and updated call sites. Please review updated code for errors.");
+  } else {
+    vscode.window.showInformationMessage(
+      "Converted script to static types and updated call sites. Please review updated code for errors."
+    );
   }
 }
 
@@ -200,29 +202,31 @@ export function activateLanguageServer(
   context: vscode.ExtensionContext,
   trackEvent: TrackEvent
 ) {
-  vscode.workspace.onDidChangeConfiguration((event: vscode.ConfigurationChangeEvent) => {
-    const shouldRestart =
-      event.affectsConfiguration("nextflow.java.home") ||
-      event.affectsConfiguration("nextflow.languageVersion");
-    if (shouldRestart) {
-      restartLanguageServer(context);
+  vscode.workspace.onDidChangeConfiguration(
+    (event: vscode.ConfigurationChangeEvent) => {
+      const shouldRestart =
+        event.affectsConfiguration("nextflow.java.home") ||
+        event.affectsConfiguration("nextflow.languageVersion");
+      if (shouldRestart) {
+        restartLanguageServer(context);
+      }
     }
+  );
+  vscode.commands.registerCommand("nextflow.previewDag", (uri, name) => {
+    previewDag(context, uri, name);
   });
   vscode.commands.registerCommand(
-    "nextflow.previewDag",
-    (uri, name) => { previewDag(context, uri, name); }
-  );
-  vscode.commands.registerCommand(
     "nextflow.languageServer.convertScriptToTyped",
-    () => { convertScriptToTyped(); }
+    () => {
+      convertScriptToTyped();
+    }
   );
-  vscode.commands.registerCommand(
-    "nextflow.languageServer.restart",
-    () => { restartLanguageServer(context); }
-  );
-  vscode.commands.registerCommand("nextflow.languageServer.stop",
-    () => { stopLanguageServer(); }
-  );
+  vscode.commands.registerCommand("nextflow.languageServer.restart", () => {
+    restartLanguageServer(context);
+  });
+  vscode.commands.registerCommand("nextflow.languageServer.stop", () => {
+    stopLanguageServer();
+  });
   vscode.commands.registerCommand(
     "nextflow.openFileFromWebview",
     async (uriString: string) => {

--- a/src/languageServer/utils/fetchLanguageServer.ts
+++ b/src/languageServer/utils/fetchLanguageServer.ts
@@ -36,9 +36,14 @@ async function getLatestRemoteVersion(
       const matchingReleases = (releases as any[])
         .filter((release) => release.tag_name.startsWith(versionPrefix))
         .filter((release) => !release.tag_name.endsWith("PREVIEW"))
-        .sort((a, b) => b.tag_name.localeCompare(a.tag_name, undefined, { numeric: true }));
+        .sort((a, b) =>
+          b.tag_name.localeCompare(a.tag_name, undefined, { numeric: true })
+        );
       return matchingReleases.length > 0
-        ? { tag: matchingReleases[0].tag_name, updatedAt: matchingReleases[0].updated_at }
+        ? {
+            tag: matchingReleases[0].tag_name,
+            updatedAt: matchingReleases[0].updated_at
+          }
         : null;
     }
   } catch (error) {
@@ -48,12 +53,13 @@ async function getLatestRemoteVersion(
 
 async function getGitHubToken(): Promise<string | undefined> {
   try {
-    const session = await vscode.authentication.getSession("github", ["repo"], { silent: true });
+    const session = await vscode.authentication.getSession("github", ["repo"], {
+      silent: true
+    });
     if (session?.accessToken) {
       return session.accessToken;
     }
-  } catch (error) {
-  }
+  } catch (error) {}
   return process.env.GITHUB_TOKEN;
 }
 
@@ -98,7 +104,10 @@ export async function fetchLanguageServer(context: vscode.ExtensionContext) {
   const versionPrefix = `v${languageVersion.replace(" (preview)", "")}`;
   let resolvedVersion: string | null = null;
   let remoteUpdatedAt: string | null = null;
-  const remoteVersionResponse = await getLatestRemoteVersion(versionPrefix, isPreview);
+  const remoteVersionResponse = await getLatestRemoteVersion(
+    versionPrefix,
+    isPreview
+  );
   if (remoteVersionResponse) {
     resolvedVersion = remoteVersionResponse.tag;
     remoteUpdatedAt = remoteVersionResponse.updatedAt;

--- a/src/languageServer/utils/findJava.ts
+++ b/src/languageServer/utils/findJava.ts
@@ -1,7 +1,7 @@
-import * as cp from 'child_process';
+import * as cp from "child_process";
 import * as fs from "fs";
 import * as path from "path";
-import * as semver from 'semver';
+import * as semver from "semver";
 import * as vscode from "vscode";
 
 function isFile(javaPath: string): boolean {
@@ -9,9 +9,8 @@ function isFile(javaPath: string): boolean {
 }
 
 export function findJava(): string | null {
-  const executableFile: string = (process["platform"] === "win32")
-    ? "java.exe"
-    : "java";
+  const executableFile: string =
+    process["platform"] === "win32" ? "java.exe" : "java";
 
   const settingsJavaHome = vscode.workspace
     .getConfiguration("nextflow")
@@ -48,15 +47,17 @@ export function findJava(): string | null {
 }
 
 export function checkJavaVersion(javaPath: string): boolean {
-  const output = cp.execSync(`"${javaPath}" -version 2>&1`, { encoding: 'utf8' });
+  const output = cp.execSync(`"${javaPath}" -version 2>&1`, {
+    encoding: "utf8"
+  });
   const match = output.match(/version "(.*?)"/);
   if (!match || match.length < 2) {
-    throw new Error('Could not parse Java version');
+    throw new Error("Could not parse Java version");
   }
 
   const versionString = match[1];
-  const version = versionString.startsWith('1.')
-    ? versionString.replace(/^1\./, '') // e.g. "1.8.0" → "8.0"
+  const version = versionString.startsWith("1.")
+    ? versionString.replace(/^1\./, "") // e.g. "1.8.0" → "8.0"
     : versionString;
 
   const coerced = semver.coerce(version);
@@ -64,5 +65,5 @@ export function checkJavaVersion(javaPath: string): boolean {
     throw new Error(`Invalid Java version format: ${coerced}`);
   }
 
-  return semver.gte(coerced, '17.0.0');
+  return semver.gte(coerced, "17.0.0");
 }

--- a/src/nextflowLog/decorate.ts
+++ b/src/nextflowLog/decorate.ts
@@ -14,9 +14,7 @@ function readOpacity(): number {
   return Math.max(0.1, Math.min(1.0, value));
 }
 
-function makeDimDecoration(
-  opacity: number
-): vscode.TextEditorDecorationType {
+function makeDimDecoration(opacity: number): vscode.TextEditorDecorationType {
   return vscode.window.createTextEditorDecorationType({
     opacity: String(opacity),
     rangeBehavior: vscode.DecorationRangeBehavior.OpenOpen

--- a/src/nextflowLog/filter.ts
+++ b/src/nextflowLog/filter.ts
@@ -34,7 +34,9 @@ interface FilterItem extends vscode.QuickPickItem {
 }
 
 function readDefaultFilterEnabled(): boolean {
-  return vscode.workspace.getConfiguration().get<boolean>(FILTER_ENABLED_KEY, true);
+  return vscode.workspace
+    .getConfiguration()
+    .get<boolean>(FILTER_ENABLED_KEY, true);
 }
 
 function readDefaultHiddenLevels(): Set<LogLevel> {
@@ -51,14 +53,16 @@ function readDefaultHiddenLevels(): Set<LogLevel> {
 }
 
 function readDefaultStripAnsi(): boolean {
-  return vscode.workspace.getConfiguration().get<boolean>(FILTER_STRIP_ANSI_KEY, true);
+  return vscode.workspace
+    .getConfiguration()
+    .get<boolean>(FILTER_STRIP_ANSI_KEY, true);
 }
 
 function defaultState(): FileState {
   return {
     filterEnabled: readDefaultFilterEnabled(),
     hidden: readDefaultHiddenLevels(),
-    stripAnsi: readDefaultStripAnsi(),
+    stripAnsi: readDefaultStripAnsi()
   };
 }
 
@@ -89,8 +93,7 @@ async function saveAllSettings(
 
 function describeState(state: FileState): string {
   if (!state.filterEnabled) return "$(file) Raw file (click to change)";
-  if (state.hidden.size === 0)
-    return "$(list-filter) Filter log levels";
+  if (state.hidden.size === 0) return "$(list-filter) Filter log levels";
   const visible = LOG_LEVELS.filter((l) => !state.hidden.has(l));
   return `$(list-filter) ${visible.length ? `Showing: ${visible.join(" · ")}` : "Nothing visible"}`;
 }

--- a/src/nextflowLog/filteredView.ts
+++ b/src/nextflowLog/filteredView.ts
@@ -29,7 +29,9 @@ export interface ViewState {
 }
 
 export class FilteredLogProvider implements vscode.FileSystemProvider {
-  private readonly emitter = new vscode.EventEmitter<vscode.FileChangeEvent[]>();
+  private readonly emitter = new vscode.EventEmitter<
+    vscode.FileChangeEvent[]
+  >();
   readonly onDidChangeFile = this.emitter.event;
 
   constructor(

--- a/src/nextflowLog/parseEntries.ts
+++ b/src/nextflowLog/parseEntries.ts
@@ -65,7 +65,10 @@ export function getEntries(document: vscode.TextDocument): LogEntry[] {
   return entries;
 }
 
-export function entryRange(entry: LogEntry, document: vscode.TextDocument): vscode.Range {
+export function entryRange(
+  entry: LogEntry,
+  document: vscode.TextDocument
+): vscode.Range {
   const end = document.lineAt(entry.endLine).range.end;
   return new vscode.Range(entry.startLine, 0, end.line, end.character);
 }

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -43,11 +43,13 @@ export function activateTelemetry(context: vscode.ExtensionContext) {
   // Track file open events
   const trackFileOpens = vscode.workspace.onDidOpenTextDocument((document) => {
     const fileName = document.fileName.toLowerCase();
-    const fileType = 
-      fileName.endsWith(".nf.test") ? ".nf.test"
-      : fileName.endsWith(".nf") ? ".nf"
-      : fileName.endsWith(".config") ? ".config"
-      : undefined;
+    const fileType = fileName.endsWith(".nf.test")
+      ? ".nf.test"
+      : fileName.endsWith(".nf")
+        ? ".nf"
+        : fileName.endsWith(".config")
+          ? ".config"
+          : undefined;
     if (fileType) {
       trackEvent("fileOpened", { fileType });
     }
@@ -99,13 +101,13 @@ function createTrackEvent(context: vscode.ExtensionContext) {
 }
 
 function isTelemetryEnabled(): boolean {
-    const globalTelemetryLevel = vscode.workspace
-      .getConfiguration("telemetry")
-      .get<string>("telemetryLevel", "all");
-    const enabled = vscode.workspace
-      .getConfiguration("nextflow")
-      .get<boolean>("telemetry.enabled", false);
-    return globalTelemetryLevel !== "off" && enabled;
+  const globalTelemetryLevel = vscode.workspace
+    .getConfiguration("telemetry")
+    .get<string>("telemetryLevel", "all");
+  const enabled = vscode.workspace
+    .getConfiguration("nextflow")
+    .get<boolean>("telemetry.enabled", false);
+  return globalTelemetryLevel !== "off" && enabled;
 }
 
 function getUserId(context: vscode.ExtensionContext): string {
@@ -117,7 +119,9 @@ function getUserId(context: vscode.ExtensionContext): string {
   return anonId;
 }
 
-export function deactivateTelemetry(context: vscode.ExtensionContext): Thenable<void> {
+export function deactivateTelemetry(
+  context: vscode.ExtensionContext
+): Thenable<void> {
   if (!isTelemetryEnabled() || !posthogClient) {
     return Promise.resolve();
   }

--- a/src/webview/ResourcesProvider.ts
+++ b/src/webview/ResourcesProvider.ts
@@ -80,9 +80,9 @@ class ResourcesProvider implements vscode.TreeDataProvider<ResourceItem> {
       return Promise.resolve([]);
     } else {
       return Promise.resolve(
-        this.resources.map((resource) => (
-          new ResourceItem(resource.label, resource.url)
-        ))
+        this.resources.map(
+          (resource) => new ResourceItem(resource.label, resource.url)
+        )
       );
     }
   }

--- a/src/webview/WebviewProvider/lib/workspace/queryWorkspace.ts
+++ b/src/webview/WebviewProvider/lib/workspace/queryWorkspace.ts
@@ -5,32 +5,30 @@ import * as vscode from "vscode";
 import { TestNode, TreeNode } from "./types";
 
 function findFiles(dir: string, extension: string): string[] {
-  return fs.readdirSync(dir, { withFileTypes: true })
-    .flatMap((entry) => {
-      const filePath = path.join(dir, entry.name);
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const filePath = path.join(dir, entry.name);
 
-      if (entry.isDirectory())
-        return findFiles(filePath, extension);
-      if (entry.isFile() && entry.name.endsWith(extension))
-        return [filePath];
-      return [];
-    });
+    if (entry.isDirectory()) return findFiles(filePath, extension);
+    if (entry.isFile() && entry.name.endsWith(extension)) return [filePath];
+    return [];
+  });
 }
 
 function getLineNumber(text: string, charIndex: number): number {
   return text.slice(0, charIndex).split("\n").length - 1;
-};
+}
 
 function parseNfTest(filePath: string): TestNode[] {
   const text = fs.readFileSync(filePath, "utf8");
   const matches = text.matchAll(/^\s*(process|workflow)\s+"(\w+)"/gm);
-  return [...matches].map((m) => (
-    {
-      name: m[2],
-      path: filePath,
-      line: getLineNumber(text, m.index)
-    } as TestNode
-  ));
+  return [...matches].map(
+    (m) =>
+      ({
+        name: m[2],
+        path: filePath,
+        line: getLineNumber(text, m.index)
+      }) as TestNode
+  );
 }
 
 function findNfTests(dir: string): TestNode[] {
@@ -39,7 +37,10 @@ function findNfTests(dir: string): TestNode[] {
 
 async function previewWorkspace(name: string): Promise<any> {
   try {
-    return await vscode.commands.executeCommand("nextflow.server.previewWorkspace", name);
+    return await vscode.commands.executeCommand(
+      "nextflow.server.previewWorkspace",
+      name
+    );
   } catch (error) {
     return null;
   }
@@ -47,24 +48,22 @@ async function previewWorkspace(name: string): Promise<any> {
 
 export async function queryWorkspace(): Promise<TreeNode[]> {
   const folders = vscode.workspace.workspaceFolders;
-  if (!folders || folders.length == 0)
-    return [];
+  if (!folders || folders.length == 0) return [];
 
   const name = folders[0].name;
   const res: any = await previewWorkspace(name);
   if (!res || !res.result) {
-    if (res?.error)
-      vscode.window.showErrorMessage(res.error);
+    if (res?.error) vscode.window.showErrorMessage(res.error);
     return [];
   }
 
   const nodes = res.result as TreeNode[];
-  const tests = new Map<string,TestNode[]>()
+  const tests = new Map<string, TestNode[]>();
 
   nodes.forEach((node) => {
     const filePath = node.path;
     if (!tests.has(filePath)) {
-      tests.set(filePath, findNfTests(path.dirname(filePath)))
+      tests.set(filePath, findNfTests(path.dirname(filePath)));
     }
     node.test = tests.get(filePath)?.find((test) => test.name === node.name);
   });

--- a/src/webview/WebviewProvider/lib/workspace/types.ts
+++ b/src/webview/WebviewProvider/lib/workspace/types.ts
@@ -1,4 +1,3 @@
-
 export interface TreeNode {
   name: string;
   type: "process" | "workflow";

--- a/src/webview/index.ts
+++ b/src/webview/index.ts
@@ -18,12 +18,9 @@ export function activateWebview(
     "seqeraCloud",
     authProvider
   );
-  
+
   const refresh = (uris?: readonly vscode.Uri[]) => {
-    if (
-      uris === undefined ||
-      uris.some((uri) => isNextflowFile(uri.fsPath))
-    ) {
+    if (uris === undefined || uris.some((uri) => isNextflowFile(uri.fsPath))) {
       projectProvider.initViewData();
     }
   };
@@ -31,7 +28,10 @@ export function activateWebview(
   // Register views
   const providers = [
     vscode.window.registerWebviewViewProvider("project", projectProvider),
-    vscode.window.registerWebviewViewProvider("seqeraCloud", seqeraCloudProvider),
+    vscode.window.registerWebviewViewProvider(
+      "seqeraCloud",
+      seqeraCloudProvider
+    ),
     vscode.window.registerTreeDataProvider("resources", resourcesProvider)
   ];
 
@@ -49,7 +49,9 @@ export function activateWebview(
   vscode.workspace.onDidSaveTextDocument((e) => refresh([e.uri]));
   vscode.workspace.onDidCreateFiles((e) => refresh(e.files));
   vscode.workspace.onDidDeleteFiles((e) => refresh(e.files));
-  vscode.workspace.onDidRenameFiles((e) => refresh(e.files.map((r) => r.newUri)));
+  vscode.workspace.onDidRenameFiles((e) =>
+    refresh(e.files.map((r) => r.newUri))
+  );
   vscode.workspace.onDidChangeWorkspaceFolders((_) => refresh());
 
   return providers;

--- a/webview-ui/eslint.config.js
+++ b/webview-ui/eslint.config.js
@@ -1,28 +1,28 @@
-import js from '@eslint/js'
-import globals from 'globals'
-import reactHooks from 'eslint-plugin-react-hooks'
-import reactRefresh from 'eslint-plugin-react-refresh'
-import tseslint from 'typescript-eslint'
+import js from "@eslint/js";
+import globals from "globals";
+import reactHooks from "eslint-plugin-react-hooks";
+import reactRefresh from "eslint-plugin-react-refresh";
+import tseslint from "typescript-eslint";
 
 export default tseslint.config(
-  { ignores: ['dist'] },
+  { ignores: ["dist"] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
-    files: ['**/*.{ts,tsx}'],
+    files: ["**/*.{ts,tsx}"],
     languageOptions: {
       ecmaVersion: 2020,
-      globals: globals.browser,
+      globals: globals.browser
     },
     plugins: {
-      'react-hooks': reactHooks,
-      'react-refresh': reactRefresh,
+      "react-hooks": reactHooks,
+      "react-refresh": reactRefresh
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
-      'react-refresh/only-export-components': [
-        'warn',
-        { allowConstantExport: true },
-      ],
-    },
-  },
-)
+      "react-refresh/only-export-components": [
+        "warn",
+        { allowConstantExport: true }
+      ]
+    }
+  }
+);

--- a/webview-ui/src/Context/TowerProvider/index.tsx
+++ b/webview-ui/src/Context/TowerProvider/index.tsx
@@ -25,13 +25,15 @@ import {
   filterComputeEnvs
 } from "./utils";
 
-const TowerContext = createContext<TowerContextType>(null as any);
+const TowerContext = createContext<TowerContextType>(
+  null as unknown as TowerContextType
+);
 
 type Props = {
   children: React.ReactNode;
   authState?: AuthState;
   platformData: PlatformData;
-  vscode: any;
+  vscode: VSCodeApi;
 };
 
 type PlatformData = {

--- a/webview-ui/src/Context/WorkspaceProvider/index.tsx
+++ b/webview-ui/src/Context/WorkspaceProvider/index.tsx
@@ -40,7 +40,7 @@ interface WorkspaceContextType {
 
 type Props = {
   children: React.ReactNode;
-  vscode: any;
+  vscode: VSCodeApi;
   viewID: string;
 };
 

--- a/webview-ui/src/Context/index.tsx
+++ b/webview-ui/src/Context/index.tsx
@@ -16,7 +16,7 @@ import {
   HubPipeline
 } from "./types";
 
-const vscode = getVscode();
+const vscode = getVscode() as VSCodeApi;
 
 type Props = {
   children: React.ReactNode;

--- a/webview-ui/src/Layout/Project/index.tsx
+++ b/webview-ui/src/Layout/Project/index.tsx
@@ -21,20 +21,17 @@ const Project = () => {
 
   function testCoverage() {
     const totalCount = nodes.length - entryNodes.length;
-    if( totalCount == 0 )
-      return <></>;
+    if (totalCount == 0) return <></>;
     const testCount = nodes.filter((n) => n.test !== undefined).length;
     const coverage = round((testCount / totalCount) * 100);
     const color =
-      coverage >= 80 ? "#0dc09d" :
-      coverage >= 20 ? "orange" :
-      "red";
+      coverage >= 80 ? "#0dc09d" : coverage >= 20 ? "orange" : "red";
     return (
       <div className={styles.header}>
         Test coverage: <span style={{ color }}>{coverage}%</span>
       </div>
     );
-  };
+  }
 
   function treeView() {
     if (entryNodes.length == 0)
@@ -46,7 +43,7 @@ const Project = () => {
         ))}
       </div>
     );
-  };
+  }
 
   function listView() {
     const filteredNodes = search
@@ -54,9 +51,11 @@ const Project = () => {
       : nodes.slice();
     filteredNodes.sort((a, b) => a.name.localeCompare(b.name));
     if (filteredNodes.length == 0)
-      return <section className="cozy">No processes or workflows found</section>;
+      return (
+        <section className="cozy">No processes or workflows found</section>
+      );
     return <FileList nodes={filteredNodes} />;
-  };
+  }
 
   return (
     <>

--- a/webview-ui/src/Layout/SeqeraCloud/Workspace/RunHistory/utils.ts
+++ b/webview-ui/src/Layout/SeqeraCloud/Workspace/RunHistory/utils.ts
@@ -6,16 +6,13 @@ import {
 
 export { formatDate, relativeTime } from "../../utils";
 
-export function getRunURL(
-  workspace: Workspace | undefined,
-  item: Workflow
-) {
+export function getRunURL(workspace: Workspace | undefined, item: Workflow) {
   if (!workspace) return "";
 
   return `${SEQERA_PLATFORM_URL}/orgs/${workspace.orgName}/workspaces/${workspace.workspaceName}/watch/${item.id}`;
 }
 
-export const getRuntimeMinutes = (workflow: any) => {
+export const getRuntimeMinutes = (workflow: Workflow) => {
   if (!workflow.complete) return null;
   const start = new Date(workflow.dateCreated).getTime();
   const end = new Date(workflow.complete).getTime();

--- a/webview-ui/src/components/FileList/ItemActions/index.tsx
+++ b/webview-ui/src/components/FileList/ItemActions/index.tsx
@@ -50,7 +50,14 @@ const ItemActions: React.FC<Props> = ({ node }) => {
             !!node.test && openFile(node.test.path, node.test.line)
           }
         >
-          <i className={clsx("codicon", "codicon-beaker", styles.actionIcon, styles.actionGo)} />
+          <i
+            className={clsx(
+              "codicon",
+              "codicon-beaker",
+              styles.actionIcon,
+              styles.actionGo
+            )}
+          />
         </button>
       ) : (
         <button

--- a/webview-ui/src/components/FileList/ItemActions/styles.module.css
+++ b/webview-ui/src/components/FileList/ItemActions/styles.module.css
@@ -33,7 +33,7 @@
     }
     & .wave {
       opacity: 1;
-      fill: #3D95FD;
+      fill: #3d95fd;
     }
   }
   &.success,
@@ -59,14 +59,14 @@
     transition: opacity 0.1s;
   }
   & .actionGo {
-    color: #388A34;
+    color: #388a34;
   }
   & .wave {
     width: 21px;
     height: 21px;
     transition: fill 0.2s;
     opacity: 0.8;
-    fill: #77B5FE;
+    fill: #77b5fe;
   }
 }
 &:hover {

--- a/webview-ui/src/vite-env.d.ts
+++ b/webview-ui/src/vite-env.d.ts
@@ -3,11 +3,15 @@
 export {};
 
 declare global {
+  interface VSCodeApi {
+    postMessage: (msg: unknown) => void;
+    getState: () => { selectedItems?: string[] } | undefined;
+    setState: (state: { selectedItems?: string[] }) => void;
+  }
+
   interface Window {
-    acquireVsCodeApi: () => {
-      postMessage: (msg: any) => void;
-    };
-    vscode: any;
+    acquireVsCodeApi: () => VSCodeApi;
+    vscode: VSCodeApi | undefined;
     initialData: {
       viewID: "project" | "seqeraCloud";
     };


### PR DESCRIPTION
## Summary

This repository previously had no automated CI — the only workflow was the manually-triggered publish job, so nothing validated pull requests. This PR adds a CI workflow that runs every check the existing tooling supports, fixes the issues those checks surfaced so CI is green from the first run, and hardens both workflows following security best practice.

## New CI workflow

`.github/workflows/ci.yml` runs on pushes to `main`, on pull requests, and via manual dispatch, with three parallel jobs built from the tooling already configured in the repo (there was no pre-commit config to reuse):

- **Prettier** — `prettier --check .` across the repo, using the existing `.prettierrc`
- **ESLint** — `npm run lint` in `webview-ui`
- **Type check & build** — `npm run check-types` plus the full `npm run package` (the same build the publish workflow uses), uploading the resulting `nextflow.vsix` as a workflow artifact so every PR produces an installable extension

There is no test suite in the repo, so there is no test job; one can slot in alongside the build job if tests are added later.

## Fixes to make CI pass

- **ESLint**: fixed all 6 `@typescript-eslint/no-explicit-any` errors by adding a typed `VSCodeApi` interface for the webview messaging API and typing `getRuntimeMinutes` with the existing `Workflow` type. The remaining `react-hooks/exhaustive-deps` warnings are non-blocking and left untouched, since fixing them would change runtime behaviour.
- **Prettier**: ran `prettier --write` across the repo (20 files, formatting churn only, isolated in its own commit) and added `dist` to `.prettierignore` so webview build output can't trip the check.

## Workflow hardening

Applied to both the new CI workflow and the existing publish workflow:

- All actions updated to their latest releases and pinned to commit SHAs with version comments (`actions/checkout` v7.0.0, `actions/setup-node` v7.0.0, `actions/upload-artifact` v7.0.1, `HaaLeo/publish-vscode-extension` v2.0.0 — checked the v1→v2 changelog: internal vsce/ovsx bumps only, no input changes)
- All [zizmor](https://docs.zizmor.sh/) findings fixed, clean even at `--persona=pedantic`: `persist-credentials: false` on every checkout, explicit least-privilege `permissions: contents: read` blocks, and concurrency limits on both workflows

## Verification

All three checks plus the full `vsce` package build were run locally and pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019LBqT8H8doFvuK9xTq1q6a